### PR TITLE
Add AIRTABLE_API_KEY environment variable

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -161,5 +161,13 @@ export const packageHelpers: PackageHelpers = {
         argName: 'token'
       }
     }
+  },
+  'airtable-mcp-server': {
+    requiredEnvVars: {
+      AIRTABLE_API_KEY: {
+        description: 'API key for Airtable (can also be provided via command line)',
+        required: false
+      }
+    }
   }
 };


### PR DESCRIPTION
Added required environment variable documentation for airtable-mcp-server package.

Link to Devin run: https://app.devin.ai/sessions/755a568d62874c7c9379101676d4677d